### PR TITLE
Run api-compare via CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,11 @@ before_script:
 jobs:
   include:
     - stage: Test
-      php: 7.1
-      script: vendor/bin/phpunit
-
-    - stage: Test
       php: 7.2
       script: vendor/bin/phpunit
 
     - stage: Code Coverage
-      php: 7.1
+      php: 7.2
       before_script:
         - wget https://scrutinizer-ci.com/ocular.phar
         - composer install

--- a/bin/api-compare
+++ b/bin/api-compare
@@ -1,0 +1,6 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/api-compare.php';

--- a/bin/api-compare.php
+++ b/bin/api-compare.php
@@ -18,12 +18,14 @@ if (!$foundAutoload) {
     throw new \RuntimeException('Could not find Composer autoload.php');
 }
 
-$application = new Application();
-$application->add(new Command\ApiCompare(
+$apiCompareCommand = new Command\ApiCompare(
     new \Roave\ApiCompare\Git\GitCheckoutRevisionToTemporaryPath(),
     new \Roave\ApiCompare\Factory\DirectoryReflectorFactory()
-));
-$application->setDefaultCommand('api-compare:compare');
+);
+
+$application = new Application();
+$application->add($apiCompareCommand);
+$application->setDefaultCommand($apiCompareCommand->getName());
 
 /** @noinspection PhpUnhandledExceptionInspection */
 $application->run();

--- a/bin/api-compare.php
+++ b/bin/api-compare.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+use Assert\Assert;
+use Roave\ApiCompare\Comparator;
+use Roave\ApiCompare\Factory\DirectoryReflectorFactory;
+use Roave\ApiCompare\Formatter\SymfonyConsoleTextFormatter;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+$foundAutoload = false;
+foreach ([__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../autoload.php'] as $autoload) {
+    if (file_exists($autoload)) {
+        /** @noinspection PhpIncludeInspection */
+        require $autoload;
+        $foundAutoload = true;
+        break;
+    }
+}
+
+if (!$foundAutoload) {
+    throw new \RuntimeException('Could not find Composer autoload.php');
+}
+
+$application = new Application();
+$application->add(new class extends Command {
+    /**
+     *
+     * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
+     */
+    protected function configure() : void
+    {
+        $this
+            ->setName('api-compare:compare')
+            ->setDescription('List comparisons between class APIs')
+            ->addArgument('from', InputArgument::REQUIRED)
+            ->addArgument('to', InputArgument::REQUIRED)
+        ;
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
+     * @throws \Roave\BetterReflection\SourceLocator\Exception\InvalidFileInfo
+     * @throws \Roave\BetterReflection\SourceLocator\Exception\InvalidDirectory
+     */
+    protected function execute(InputInterface $input, OutputInterface $output) : void
+    {
+        $reflectorFactory = new DirectoryReflectorFactory();
+
+        (new SymfonyConsoleTextFormatter($output))->write(
+            (new Comparator())->compare(
+                $reflectorFactory->__invoke($this->validatePath($input->getArgument('from'))),
+                $reflectorFactory->__invoke($this->validatePath($input->getArgument('to')))
+            )
+        );
+    }
+
+    /**
+     * @param string $path
+     * @return string
+     * @throws InvalidArgumentException
+     */
+    private function validatePath(string $path) : string
+    {
+        Assert::that($path)->directory();
+        return realpath($path);
+    }
+});
+$application->setDefaultCommand('api-compare:compare');
+
+/** @noinspection PhpUnhandledExceptionInspection */
+$application->run();

--- a/bin/api-compare.php
+++ b/bin/api-compare.php
@@ -1,18 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Assert\Assert;
-use Roave\ApiCompare\Comparator;
-use Roave\ApiCompare\Factory\DirectoryReflectorFactory;
-use Roave\ApiCompare\Formatter\SymfonyConsoleTextFormatter;
-use Roave\ApiCompare\Git\CheckedOutRepository;
-use Roave\ApiCompare\Git\GitCheckoutRevisionToTemporaryPath;
-use Roave\ApiCompare\Git\Revision;
+use Roave\ApiCompare\Command;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 $foundAutoload = false;
 foreach ([__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../autoload.php'] as $autoload) {
@@ -29,54 +19,10 @@ if (!$foundAutoload) {
 }
 
 $application = new Application();
-$application->add(new class extends Command {
-    /**
-     *
-     * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
-     */
-    protected function configure() : void
-    {
-        $this
-            ->setName('api-compare:compare')
-            ->setDescription('List comparisons between class APIs')
-            ->addArgument('from', InputArgument::REQUIRED)
-            ->addArgument('to', InputArgument::REQUIRED)
-        ;
-    }
-
-    /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     * @throws \Symfony\Component\Process\Exception\RuntimeException
-     * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
-     * @throws \Roave\BetterReflection\SourceLocator\Exception\InvalidFileInfo
-     * @throws \Roave\BetterReflection\SourceLocator\Exception\InvalidDirectory
-     */
-    protected function execute(InputInterface $input, OutputInterface $output) : void
-    {
-        $reflectorFactory = new DirectoryReflectorFactory();
-        $git = new GitCheckoutRevisionToTemporaryPath();
-
-        // @todo fix flaky assumption about the path of the source repo...
-        $sourceRepo = CheckedOutRepository::fromPath(getcwd());
-
-        $fromPath = $git->checkout($sourceRepo, Revision::fromSha1($input->getArgument('from')));
-        $toPath = $git->checkout($sourceRepo, Revision::fromSha1($input->getArgument('to')));
-
-        // @todo fix hard-coded /src/ addition...
-        try {
-            (new SymfonyConsoleTextFormatter($output))->write(
-                (new Comparator())->compare(
-                    $reflectorFactory->__invoke((string)$fromPath . '/src/'),
-                    $reflectorFactory->__invoke((string)$toPath . '/src/')
-                )
-            );
-        } finally {
-            $git->remove($fromPath);
-            $git->remove($toPath);
-        }
-    }
-});
+$application->add(new Command\ApiCompare(
+    new \Roave\ApiCompare\Git\GitCheckoutRevisionToTemporaryPath(),
+    new \Roave\ApiCompare\Factory\DirectoryReflectorFactory()
+));
 $application->setDefaultCommand('api-compare:compare');
 
 /** @noinspection PhpUnhandledExceptionInspection */

--- a/bin/api-compare.php
+++ b/bin/api-compare.php
@@ -1,31 +1,37 @@
 <?php
+
 declare(strict_types=1);
 
-use Roave\ApiCompare\Command;
-use Symfony\Component\Console\Application;
+namespace Roave\ApiCompareCli;
 
-$foundAutoload = false;
-foreach ([__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../autoload.php'] as $autoload) {
-    if (file_exists($autoload)) {
+use Roave\ApiCompare\Command;
+use RuntimeException;
+use Symfony\Component\Console\Application;
+use function file_exists;
+
+(function () {
+    foreach ([__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../autoload.php'] as $autoload) {
+        if (! file_exists($autoload)) {
+            continue;
+        }
+
         /** @noinspection PhpIncludeInspection */
         require $autoload;
-        $foundAutoload = true;
-        break;
+
+        $apiCompareCommand = new Command\ApiCompare(
+            new \Roave\ApiCompare\Git\GitCheckoutRevisionToTemporaryPath(),
+            new \Roave\ApiCompare\Factory\DirectoryReflectorFactory()
+        );
+
+        $application = new Application();
+        $application->add($apiCompareCommand);
+        $application->setDefaultCommand($apiCompareCommand->getName());
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $application->run();
+
+        return;
     }
-}
 
-if (!$foundAutoload) {
-    throw new \RuntimeException('Could not find Composer autoload.php');
-}
-
-$apiCompareCommand = new Command\ApiCompare(
-    new \Roave\ApiCompare\Git\GitCheckoutRevisionToTemporaryPath(),
-    new \Roave\ApiCompare\Factory\DirectoryReflectorFactory()
-);
-
-$application = new Application();
-$application->add($apiCompareCommand);
-$application->setDefaultCommand($apiCompareCommand->getName());
-
-/** @noinspection PhpUnhandledExceptionInspection */
-$application->run();
+    throw new RuntimeException('Could not find Composer autoload.php');
+})();

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "roave/api-compare",
     "description": "Tool to compare two revisions of a public API to check for BC breaks",
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "roave/security-advisories": "dev-master",
         "roave/better-reflection": "^2.0",
         "symfony/console": "^4.0",
@@ -16,7 +16,7 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "^6.4"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,9 @@
     "require": {
         "php": "^7.1",
         "roave/security-advisories": "dev-master",
-        "roave/better-reflection": "^2.0"
+        "roave/better-reflection": "^2.0",
+        "symfony/console": "^4.0",
+        "beberlei/assert": "^2.9"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "roave/security-advisories": "dev-master",
         "roave/better-reflection": "^2.0",
         "symfony/console": "^4.0",
-        "beberlei/assert": "^2.9"
+        "beberlei/assert": "^2.9",
+        "symfony/process": "^4.0"
     },
     "license": "MIT",
     "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "180513de9683827a2ad1e91e8bd5b0b1",
+    "content-hash": "07f029001a820254893959c3dbd25819",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -63,16 +63,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v3.1.1",
+            "version": "v3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "a1e8e1a30e1352f118feff1a8481066ddc2f234a"
+                "reference": "bb87e28e7d7b8d9a7fda231d37457c9210faf6ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a1e8e1a30e1352f118feff1a8481066ddc2f234a",
-                "reference": "a1e8e1a30e1352f118feff1a8481066ddc2f234a",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/bb87e28e7d7b8d9a7fda231d37457c9210faf6ce",
+                "reference": "bb87e28e7d7b8d9a7fda231d37457c9210faf6ce",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2017-09-02T17:10:46+00:00"
+            "time": "2018-02-28T20:30:58+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -168,29 +168,35 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.1.1",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2"
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/reflection-common": "^1.0.0",
                 "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -209,7 +215,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-30T18:51:59+00:00"
+            "time": "2017-11-30T07:14:17+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -260,21 +266,21 @@
         },
         {
             "name": "roave/better-reflection",
-            "version": "2.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/BetterReflection.git",
-                "reference": "619be9a2cef239245d8f1f466bcddc037949b788"
+                "reference": "efc45b50cb52d5eeaacab15741376e981e28738b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/BetterReflection/zipball/619be9a2cef239245d8f1f466bcddc037949b788",
-                "reference": "619be9a2cef239245d8f1f466bcddc037949b788",
+                "url": "https://api.github.com/repos/Roave/BetterReflection/zipball/efc45b50cb52d5eeaacab15741376e981e28738b",
+                "reference": "efc45b50cb52d5eeaacab15741376e981e28738b",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^3.1.1",
-                "php": ">7.1.0,<7.3.0",
+                "php": ">=7.1.0,<7.3.0",
                 "phpdocumentor/reflection-docblock": "^4.1.1",
                 "phpdocumentor/type-resolver": "^0.4.0",
                 "roave/signature": "^1.0"
@@ -318,7 +324,7 @@
                 }
             ],
             "description": "Better Reflection - an improved code reflection API",
-            "time": "2017-09-16T20:30:16+00:00"
+            "time": "2018-02-05T08:08:57+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -326,27 +332,32 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "c16200598d3df15cc837a6605e7860f424ddd044"
+                "reference": "c83f6aa0ed08f680c012656d411d1b7c94003012"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/c16200598d3df15cc837a6605e7860f424ddd044",
-                "reference": "c16200598d3df15cc837a6605e7860f424ddd044",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/c83f6aa0ed08f680c012656d411d1b7c94003012",
+                "reference": "c83f6aa0ed08f680c012656d411d1b7c94003012",
                 "shasum": ""
             },
             "conflict": {
+                "3f/pygmentize": "<1.2",
                 "adodb/adodb-php": "<5.20.6",
-                "amphp/artax": ">=2,<2.0.6|<1.0.6",
+                "amphp/artax": "<1.0.6|>=2,<2.0.6",
+                "amphp/http": "<1.0.1",
+                "asymmetricrypt/asymmetricrypt": ">=0,<9.9.99",
                 "aws/aws-sdk-php": ">=3,<3.2.1",
                 "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
-                "cakephp/cakephp": ">=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=2.7,<2.7.6|>=3,<3.0.15|>=3.1,<3.1.4|>=1.3,<1.3.18",
+                "cakephp/cakephp": ">=1.3,<1.3.18|>=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=2.7,<2.7.6|>=3,<3.0.15|>=3.1,<3.1.4",
                 "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
-                "cartalyst/sentry": "<2.1",
+                "cartalyst/sentry": "<=2.1.6",
                 "codeigniter/framework": "<=3.0.6",
                 "composer/composer": "<=1.0.0-alpha11",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
-                "contao/core": ">=2,<3.5.28",
-                "contao/core-bundle": ">=4,<4.4.1",
+                "contao/core": ">=2,<3.5.32",
+                "contao/core-bundle": ">=4,<4.4.8",
+                "contao/listing-bundle": ">=4,<4.4.8",
+                "contao/newsletter-bundle": ">=4,<4.1",
                 "doctrine/annotations": ">=1,<1.2.7",
                 "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
                 "doctrine/common": ">=2,<2.4.3|>=2.5,<2.5.1",
@@ -357,18 +368,21 @@
                 "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
                 "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1",
                 "dompdf/dompdf": ">=0.6,<0.6.2",
-                "drupal/core": ">=8,<8.3.7",
-                "drupal/drupal": ">=8,<8.3.7",
-                "ezsystems/ezpublish-legacy": ">=2017.8,<2017.8.1.1|>=5.4,<5.4.10.1|>=5.3,<5.3.12.2",
+                "drupal/core": ">=7,<7.58|>=8,<8.4.6|>=8.5,<8.5.1",
+                "drupal/drupal": ">=7,<7.58|>=8,<8.4.6|>=8.5,<8.5.1",
+                "erusev/parsedown": "<1.7",
+                "ezsystems/ezpublish-legacy": ">=5.3,<5.3.12.3|>=5.4,<5.4.11.3|>=2017.8,<2017.8.1.1|>=2017.12,<2017.12.2.1",
                 "firebase/php-jwt": "<2",
                 "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
                 "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
+                "gree/jose": "<=2.2",
                 "gregwar/rst": "<1.0.3",
                 "guzzlehttp/guzzle": ">=6,<6.2.1|>=4.0.0-rc2,<4.2.4|>=5,<5.3.1",
-                "illuminate/auth": ">=4,<4.0.99|>=4.1,<4.1.26",
+                "illuminate/auth": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.10",
                 "illuminate/database": ">=4,<4.0.99|>=4.1,<4.1.29",
+                "illuminate/encryption": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
                 "joomla/session": "<1.3.1",
-                "laravel/framework": ">=4,<4.0.99|>=4.1,<4.1.29",
+                "laravel/framework": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
                 "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
                 "magento/magento1ce": ">=1.5.0.1,<1.9.3.2",
                 "magento/magento1ee": ">=1.9,<1.14.3.2",
@@ -378,48 +392,61 @@
                 "onelogin/php-saml": "<2.10.4",
                 "oro/crm": ">=1.7,<1.7.4",
                 "oro/platform": ">=1.7,<1.7.4",
+                "padraic/humbug_get_contents": "<1.1.2",
+                "pagarme/pagarme-php": ">=0,<3",
+                "paragonie/random_compat": "<2",
                 "phpmailer/phpmailer": ">=5,<5.2.24",
+                "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
+                "phpxmlrpc/extras": "<0.6.1",
+                "propel/propel": ">=2.0.0-alpha1,<=2.0.0-alpha7",
+                "propel/propel1": ">=1,<=1.7.1",
                 "pusher/pusher-php-server": "<2.2.1",
                 "sabre/dav": ">=1.6,<1.6.99|>=1.7,<1.7.11|>=1.8,<1.8.9",
-                "shopware/shopware": "<4.4|>=5,<5.2.16",
-                "silverstripe/cms": ">=3.1,<3.1.11|>=3,<=3.0.11",
+                "shopware/shopware": "<5.3.7",
+                "silverstripe/cms": ">=3,<=3.0.11|>=3.1,<3.1.11",
                 "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
                 "silverstripe/framework": ">=3,<3.3",
                 "silverstripe/userforms": "<3",
-                "simplesamlphp/saml2": "<1.8.1|>=1.9,<1.9.1|>=1.10,<1.10.3|>=2,<2.3.3",
-                "simplesamlphp/simplesamlphp": "<1.14.16",
+                "simplesamlphp/saml2": "<1.10.6|>=2,<2.3.8|>=3,<3.1.4",
+                "simplesamlphp/simplesamlphp": "<1.15.2",
                 "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
                 "socalnick/scn-social-auth": "<1.15.2",
-                "squizlabs/php_codesniffer": ">=1,<2.8.1",
+                "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
+                "stormpath/sdk": ">=0,<9.9.99",
                 "swiftmailer/swiftmailer": ">=4,<5.4.5",
                 "symfony/dependency-injection": ">=2,<2.0.17",
-                "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.7",
+                "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
                 "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2",
                 "symfony/http-foundation": ">=2,<2.3.27|>=2.4,<2.5.11|>=2.6,<2.6.6",
                 "symfony/http-kernel": ">=2,<2.3.29|>=2.4,<2.5.12|>=2.6,<2.6.8",
+                "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
                 "symfony/routing": ">=2,<2.0.19",
-                "symfony/security": ">=2,<2.0.25|>=2.1,<2.1.13|>=2.2,<2.2.9|>=2.3,<2.3.37|>=2.7.30,<2.7.32|>=2.8.23,<2.8.25|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5|>=2.4,<2.6.13|>=2.7,<2.7.9",
-                "symfony/security-core": ">=2.8,<2.8.6|>=3,<3.0.6|>=2.7.30,<2.7.32|>=2.8.23,<2.8.25|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5|>=2.4,<2.6.13|>=2.7,<2.7.9",
-                "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.13|>=2.8,<2.8.6|>=3,<3.0.6",
+                "symfony/security": ">=2,<2.0.25|>=2.1,<2.1.13|>=2.2,<2.2.9|>=2.3,<2.3.37|>=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8.23,<2.8.25|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5",
+                "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<2.8.6|>=2.8.23,<2.8.25|>=3,<3.0.6|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5",
+                "symfony/security-csrf": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
+                "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
                 "symfony/serializer": ">=2,<2.0.11",
-                "symfony/symfony": ">=2,<2.3.41|>=2.4,<2.7.13|>=2.8,<2.8.6|>=3,<3.0.6|>=2.7.30,<2.7.32|>=2.8.23,<2.8.25|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5",
+                "symfony/symfony": ">=2,<2.3.41|>=2.4,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
                 "symfony/translation": ">=2,<2.0.17",
                 "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
                 "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
                 "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7",
                 "thelia/backoffice-default-template": ">=2.1,<2.1.2",
-                "thelia/thelia": ">=2.1,<2.1.2|>=2.1.0-beta1,<2.1.3",
+                "thelia/thelia": ">=2.1.0-beta1,<2.1.3|>=2.1,<2.1.2",
+                "titon/framework": ">=0,<9.9.99",
                 "twig/twig": "<1.20",
                 "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.22|>=8,<8.7.5",
-                "typo3/flow": ">=2.3,<2.3.16|>=3,<3.0.10|>=1,<1.0.4|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5|>=1.1,<1.1.1|>=2,<2.0.1",
-                "typo3/neos": ">=1.2,<1.2.13|>=2,<2.0.4|>=1.1,<1.1.3",
+                "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5",
+                "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4",
                 "willdurand/js-translation-bundle": "<2.1.1",
                 "yiisoft/yii": ">=1.1.14,<1.1.15",
-                "yiisoft/yii2": "<2.0.5",
+                "yiisoft/yii2": "<2.0.15",
                 "yiisoft/yii2-bootstrap": "<2.0.4",
-                "yiisoft/yii2-dev": "<2.0.4",
+                "yiisoft/yii2-dev": "<2.0.15",
+                "yiisoft/yii2-elasticsearch": "<2.0.5",
                 "yiisoft/yii2-gii": "<2.0.4",
                 "yiisoft/yii2-jui": "<2.0.4",
+                "yiisoft/yii2-redis": "<2.0.8",
                 "zendframework/zend-cache": ">=2.4,<2.4.8|>=2.5,<2.5.3",
                 "zendframework/zend-captcha": ">=2,<2.4.9|>=2.5,<2.5.2",
                 "zendframework/zend-crypt": ">=2,<2.4.9|>=2.5,<2.5.2",
@@ -439,6 +466,7 @@
                 "zendframework/zendframework1": "<1.12.20",
                 "zendframework/zendopenid": ">=2,<2.0.2",
                 "zendframework/zendxml": ">=1,<1.0.1",
+                "zetacomponents/mail": "<1.8.2",
                 "zf-commons/zfc-user": "<1.2.2",
                 "zfcampus/zf-apigility-doctrine": ">=1,<1.0.3",
                 "zfr/zfr-oauth2-server-module": "<0.1.2"
@@ -456,7 +484,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2017-10-26T14:38:36+00:00"
+            "time": "2018-04-02T06:47:13+00:00"
         },
         {
             "name": "roave/signature",
@@ -493,16 +521,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.0.6",
+            "version": "v4.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "555c8dbe0ae9e561740451eabdbed2cc554b6a51"
+                "reference": "aad9a6fe47319f22748fd764f52d3a7ca6fa6b64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/555c8dbe0ae9e561740451eabdbed2cc554b6a51",
-                "reference": "555c8dbe0ae9e561740451eabdbed2cc554b6a51",
+                "url": "https://api.github.com/repos/symfony/console/zipball/aad9a6fe47319f22748fd764f52d3a7ca6fa6b64",
+                "reference": "aad9a6fe47319f22748fd764f52d3a7ca6fa6b64",
                 "shasum": ""
             },
             "require": {
@@ -557,7 +585,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-02-26T15:55:47+00:00"
+            "time": "2018-04-03T05:24:00+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -620,16 +648,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
                 "shasum": ""
             },
             "require": {
@@ -666,7 +694,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2018-01-29T19:49:41+00:00"
         }
     ],
     "packages-dev": [
@@ -873,16 +901,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.2",
+            "version": "1.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
                 "shasum": ""
             },
             "require": {
@@ -894,7 +922,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
             },
             "type": "library",
             "extra": {
@@ -932,45 +960,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-09-04T11:05:03+00:00"
+            "time": "2018-02-19T10:16:54+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.2.2",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "8ed1902a57849e117b5651fc1a5c48110946c06b"
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8ed1902a57849e117b5651fc1a5c48110946c06b",
-                "reference": "8ed1902a57849e117b5651fc1a5c48110946c06b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f8ca4b604baf23dab89d87773c28cc07405189ba",
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
+                "php": "^7.1",
                 "phpunit/php-file-iterator": "^1.4.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
+                "phpunit/php-token-stream": "^3.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^3.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.5",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.5"
+                "ext-xdebug": "^2.6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.2.x-dev"
+                    "dev-master": "6.0-dev"
                 }
             },
             "autoload": {
@@ -985,7 +1012,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -996,20 +1023,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-08-03T12:40:43+00:00"
+            "time": "2018-02-02T07:01:41+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -1043,7 +1070,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1088,28 +1115,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1124,7 +1151,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1133,33 +1160,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2018-02-01T13:07:23+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0"
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9a02332089ac48e704c70f6cefed30c224e3c0b0",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1182,20 +1209,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-08-20T05:47:52+00:00"
+            "time": "2018-02-01T13:16:43+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.4.3",
+            "version": "7.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "06b28548fd2b4a20c3cd6e247dc86331a7d4db13"
+                "reference": "536f4d853c12d8189963435088e8ff7c0daeab2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/06b28548fd2b4a20c3cd6e247dc86331a7d4db13",
-                "reference": "06b28548fd2b4a20c3cd6e247dc86331a7d4db13",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/536f4d853c12d8189963435088e8ff7c0daeab2e",
+                "reference": "536f4d853c12d8189963435088e8ff7c0daeab2e",
                 "shasum": ""
             },
             "require": {
@@ -1207,15 +1234,15 @@
                 "myclabs/deep-copy": "^1.6.1",
                 "phar-io/manifest": "^1.0.1",
                 "phar-io/version": "^1.0",
-                "php": "^7.0",
+                "php": "^7.1",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.2.2",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-code-coverage": "^6.0.1",
+                "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^4.0.3",
-                "sebastian/comparator": "^2.0.2",
-                "sebastian/diff": "^2.0",
+                "phpunit/php-timer": "^2.0",
+                "phpunit/phpunit-mock-objects": "^6.0",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^3.0",
                 "sebastian/environment": "^3.1",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^2.0",
@@ -1223,16 +1250,12 @@
                 "sebastian/resource-operations": "^1.0",
                 "sebastian/version": "^2.0.1"
             },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
-            },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "phpunit/php-invoker": "^2.0"
             },
             "bin": [
                 "phpunit"
@@ -1240,7 +1263,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.4.x-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -1266,33 +1289,30 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-10-16T13:18:59+00:00"
+            "time": "2018-03-26T07:36:48+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "4.0.4",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0"
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/2f789b59ab89669015ad984afa350c4ec577ade0",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
+                "php": "^7.1",
                 "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<6.0"
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1300,7 +1320,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "6.0.x-dev"
                 }
             },
             "autoload": {
@@ -1315,7 +1335,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1325,7 +1345,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-08-03T14:08:16+00:00"
+            "time": "2018-02-15T05:27:38+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1374,30 +1394,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.0.2",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "ae068fede81d06e7bb9bb46a367210a3d3e1fe6a"
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ae068fede81d06e7bb9bb46a367210a3d3e1fe6a",
-                "reference": "ae068fede81d06e7bb9bb46a367210a3d3e1fe6a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "sebastian/diff": "^2.0",
-                "sebastian/exporter": "^3.0"
+                "sebastian/diff": "^2.0 || ^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -1428,38 +1448,39 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-08-03T07:14:59+00:00"
+            "time": "2018-02-01T13:46:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "2.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^7.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1484,9 +1505,12 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-08-03T08:09:46+00:00"
+            "time": "2018-02-01T13:45:15+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1935,7 +1959,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1"
+        "php": "^7.2"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "07f029001a820254893959c3dbd25819",
+    "content-hash": "9fba18f01d80d4ee7bfdec551e07185f",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -645,6 +645,55 @@
                 "shim"
             ],
             "time": "2018-01-30T19:27:44+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v4.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "d7dc1ee5dfe9f732cb1bba7310f5b99f2b7a6d25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/d7dc1ee5dfe9f732cb1bba7310f5b99f2b7a6d25",
+                "reference": "d7dc1ee5dfe9f732cb1bba7310f5b99f2b7a6d25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-04-03T05:24:00+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,63 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd07a135e18bfd55b3b4e08d2eff8ec4",
+    "content-hash": "180513de9683827a2ad1e91e8bd5b0b1",
     "packages": [
+        {
+            "name": "beberlei/assert",
+            "version": "v2.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beberlei/assert.git",
+                "reference": "7d8108458bbe3d063dc3315278b2001a7156fade"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/7d8108458bbe3d063dc3315278b2001a7156fade",
+                "reference": "7d8108458bbe3d063dc3315278b2001a7156fade",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.1.1",
+                "phpunit/phpunit": "^4.8.35|^5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Assert\\": "lib/Assert"
+                },
+                "files": [
+                    "lib/Assert/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Collaborator"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [
+                "assert",
+                "assertion",
+                "validation"
+            ],
+            "time": "2018-03-16T17:46:00+00:00"
+        },
         {
             "name": "nikic/php-parser",
             "version": "v3.1.1",
@@ -435,6 +490,133 @@
             ],
             "description": "Sign and verify stuff",
             "time": "2017-02-17T13:53:21+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "555c8dbe0ae9e561740451eabdbed2cc554b6a51"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/555c8dbe0ae9e561740451eabdbed2cc554b6a51",
+                "reference": "555c8dbe0ae9e561740451eabdbed2cc554b6a51",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-02-26T15:55:47+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-01-30T19:27:44+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Change.php
+++ b/src/Change.php
@@ -58,7 +58,7 @@ final class Change
     {
         return sprintf(
             '%s%s: %s',
-            $this->isBcBreak ? '[BC] ' : '',
+            $this->isBcBreak ? '[BC] ' : '     ',
             strtoupper($this->modificationType),
             $this->description
         );

--- a/src/Change.php
+++ b/src/Change.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Roave\ApiCompare;
+
+use Assert\Assert;
+
+final class Change
+{
+    private const ADDED = 'added';
+    private const CHANGED = 'changed';
+    private const REMOVED = 'removed';
+
+    /**
+     * @var string[]
+     */
+    private static $validModificationTypes = [self::ADDED, self::CHANGED, self::REMOVED];
+
+    /**
+     * @var string
+     */
+    private $modificationType;
+
+    /**
+     * @var string
+     */
+    private $description;
+
+    /**
+     * @var bool
+     */
+    private $isBcBreak;
+
+    private function __construct(string $modificationType, string $description, bool $isBcBreak)
+    {
+        Assert::that($modificationType)->inArray(self::$validModificationTypes);
+        $this->modificationType = $modificationType;
+        $this->description = $description;
+        $this->isBcBreak = $isBcBreak;
+    }
+
+    public static function added(string $description, bool $isBcBreak): self
+    {
+        return new self(self::ADDED, $description, $isBcBreak);
+    }
+
+    public static function changed(string $description, bool $isBcBreak): self
+    {
+        return new self(self::CHANGED, $description, $isBcBreak);
+    }
+
+    public static function removed(string $description, bool $isBcBreak): self
+    {
+        return new self(self::REMOVED, $description, $isBcBreak);
+    }
+
+    public function __toString(): string
+    {
+        return sprintf(
+            '%s%s: %s',
+            $this->isBcBreak ? '[BC] ' : '',
+            strtoupper($this->modificationType),
+            $this->description
+        );
+    }
+}

--- a/src/Changes.php
+++ b/src/Changes.php
@@ -9,7 +9,8 @@ use IteratorAggregate;
 
 final class Changes implements IteratorAggregate
 {
-    private $changes;
+    /** @var Change[] */
+    private $changes = [];
 
     private function __construct()
     {

--- a/src/Changes.php
+++ b/src/Changes.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace Roave\ApiCompare;
 
+use ArrayIterator;
 use Assert\Assert;
+use IteratorAggregate;
 
-final class Changes
+final class Changes implements IteratorAggregate
 {
     private $changes;
 
@@ -31,5 +33,13 @@ final class Changes
         $new = clone $this;
         $new->changes[] = $change;
         return $new;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIterator() : ArrayIterator
+    {
+        return new ArrayIterator($this->changes);
     }
 }

--- a/src/Changes.php
+++ b/src/Changes.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Roave\ApiCompare;
+
+use Assert\Assert;
+
+final class Changes
+{
+    private $changes;
+
+    private function __construct()
+    {
+    }
+
+    public static function new(): self
+    {
+        return new self();
+    }
+
+    public static function fromArray(array $changes): self
+    {
+        Assert::that($changes)->all()->isInstanceOf(Change::class);
+        $instance = self::new();
+        $instance->changes = $changes;
+        return $instance;
+    }
+
+    public function withAddedChange(Change $change): self
+    {
+        $new = clone $this;
+        $new->changes[] = $change;
+        return $new;
+    }
+}

--- a/src/Command/ApiCompare.php
+++ b/src/Command/ApiCompare.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace Roave\ApiCompare\Command;
+
+use Roave\ApiCompare\Comparator;
+use Roave\ApiCompare\Factory\DirectoryReflectorFactory;
+use Roave\ApiCompare\Formatter\SymfonyConsoleTextFormatter;
+use Roave\ApiCompare\Git\CheckedOutRepository;
+use Roave\ApiCompare\Git\PerformCheckoutOfRevision;
+use Roave\ApiCompare\Git\Revision;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ApiCompare extends Command
+{
+    /** @var PerformCheckoutOfRevision */
+    private $git;
+
+    /**
+     * @var DirectoryReflectorFactory
+     */
+    private $reflectorFactory;
+
+    /**
+     * @param PerformCheckoutOfRevision $git
+     * @param DirectoryReflectorFactory $reflectorFactory
+     * @throws \Symfony\Component\Console\Exception\LogicException
+     */
+    public function __construct(
+        PerformCheckoutOfRevision $git,
+        DirectoryReflectorFactory $reflectorFactory
+    ) {
+        parent::__construct();
+        $this->git = $git;
+        $this->reflectorFactory = $reflectorFactory;
+    }
+
+    /**
+     * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
+     */
+    protected function configure() : void
+    {
+        $this
+            ->setName('api-compare:compare')
+            ->setDescription('List comparisons between class APIs')
+            ->addArgument('from', InputArgument::REQUIRED)
+            ->addArgument('to', InputArgument::REQUIRED)
+        ;
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @throws \Symfony\Component\Process\Exception\RuntimeException
+     * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
+     * @throws \Roave\BetterReflection\SourceLocator\Exception\InvalidFileInfo
+     * @throws \Roave\BetterReflection\SourceLocator\Exception\InvalidDirectory
+     */
+    protected function execute(InputInterface $input, OutputInterface $output) : void
+    {
+        // @todo fix flaky assumption about the path of the source repo...
+        $sourceRepo = CheckedOutRepository::fromPath(getcwd());
+
+        $fromPath = $this->git->checkout($sourceRepo, Revision::fromSha1($input->getArgument('from')));
+        $toPath = $this->git->checkout($sourceRepo, Revision::fromSha1($input->getArgument('to')));
+
+        // @todo fix hard-coded /src/ addition...
+        try {
+            (new SymfonyConsoleTextFormatter($output))->write(
+                (new Comparator())->compare(
+                    $this->reflectorFactory->__invoke((string)$fromPath . '/src/'),
+                    $this->reflectorFactory->__invoke((string)$toPath . '/src/')
+                )
+            );
+        } finally {
+            $this->git->remove($fromPath);
+            $this->git->remove($toPath);
+        }
+    }
+}

--- a/src/Command/ApiCompare.php
+++ b/src/Command/ApiCompare.php
@@ -59,7 +59,7 @@ final class ApiCompare extends Command
      * @throws \Roave\BetterReflection\SourceLocator\Exception\InvalidFileInfo
      * @throws \Roave\BetterReflection\SourceLocator\Exception\InvalidDirectory
      */
-    protected function execute(InputInterface $input, OutputInterface $output) : void
+    public function execute(InputInterface $input, OutputInterface $output) : void
     {
         // @todo fix flaky assumption about the path of the source repo...
         $sourceRepo = CheckedOutRepository::fromPath(getcwd());

--- a/src/Factory/DirectoryReflectorFactory.php
+++ b/src/Factory/DirectoryReflectorFactory.php
@@ -15,6 +15,12 @@ use Roave\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
  */
 final class DirectoryReflectorFactory
 {
+    /**
+     * @param string $directory
+     * @return ClassReflector
+     * @throws \Roave\BetterReflection\SourceLocator\Exception\InvalidFileInfo
+     * @throws \Roave\BetterReflection\SourceLocator\Exception\InvalidDirectory
+     */
     public function __invoke(string $directory): ClassReflector
     {
         $astLocator = (new BetterReflection())->astLocator();

--- a/src/Factory/DirectoryReflectorFactory.php
+++ b/src/Factory/DirectoryReflectorFactory.php
@@ -6,6 +6,7 @@ namespace Roave\ApiCompare\Factory;
 use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\AutoloadSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\DirectoriesSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\EvaledCodeSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
@@ -29,6 +30,7 @@ final class DirectoryReflectorFactory
                 new PhpInternalSourceLocator($astLocator),
                 new EvaledCodeSourceLocator($astLocator),
                 new DirectoriesSourceLocator([$directory], $astLocator),
+                new AutoloadSourceLocator(),
             ])
         );
     }

--- a/src/Formatter/OutputFormatter.php
+++ b/src/Formatter/OutputFormatter.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Roave\ApiCompare\Formatter;
+
+use Roave\ApiCompare\Changes;
+
+interface OutputFormatter
+{
+    public function write(Changes $changes) : void;
+}

--- a/src/Formatter/SymfonyConsoleTextFormatter.php
+++ b/src/Formatter/SymfonyConsoleTextFormatter.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Roave\ApiCompare\Formatter;
+
+use Roave\ApiCompare\Change;
+use Roave\ApiCompare\Changes;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SymfonyConsoleTextFormatter implements OutputFormatter
+{
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    public function write(Changes $changes) : void
+    {
+        /** @var Change $change */
+        foreach ($changes as $change) {
+            $this->output->writeln((string)$change);
+        }
+    }
+}

--- a/src/Git/CheckedOutRepository.php
+++ b/src/Git/CheckedOutRepository.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Roave\ApiCompare\Git;
+
+use Assert\Assert;
+
+final class CheckedOutRepository
+{
+    /** @var string */
+    private $path;
+
+    private function __construct()
+    {
+    }
+
+    public static function fromPath(string $path) : self
+    {
+        Assert::that($path)->directory();
+        Assert::that($path . '/.git')->directory();
+        $instance = new self();
+        $instance->path = $path;
+        return $instance;
+    }
+
+    public function __toString() : string
+    {
+        return $this->path;
+    }
+}

--- a/src/Git/GitCheckoutRevisionToTemporaryPath.php
+++ b/src/Git/GitCheckoutRevisionToTemporaryPath.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Roave\ApiCompare\Git;
+
+use Symfony\Component\Process\Process;
+
+final class GitCheckoutRevisionToTemporaryPath implements PerformCheckoutOfRevision
+{
+    /**
+     * {@inheritDoc}
+     * @throws \Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function checkout(CheckedOutRepository $sourceRepository, Revision $revision) : CheckedOutRepository
+    {
+        $checkoutDirectory = sys_get_temp_dir() . '/api-compare-' . (string)$revision;
+
+        (new Process(['git', 'clone', (string)$sourceRepository, $checkoutDirectory]))->mustRun();
+        (new Process(['git', 'checkout', (string)$revision]))->setWorkingDirectory($checkoutDirectory)->mustRun();
+
+        return CheckedOutRepository::fromPath($checkoutDirectory);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws \Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function remove(CheckedOutRepository $checkedOutRepository) : void
+    {
+        (new Process(['rm', '-rf', (string)$checkedOutRepository]))->mustRun();
+    }
+}

--- a/src/Git/PerformCheckoutOfRevision.php
+++ b/src/Git/PerformCheckoutOfRevision.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Roave\ApiCompare\Git;
+
+interface PerformCheckoutOfRevision
+{
+    public function checkout(CheckedOutRepository $sourceRepository, Revision $revision) : CheckedOutRepository;
+
+    public function remove(CheckedOutRepository $checkedOutRepository) : void;
+}

--- a/src/Git/Revision.php
+++ b/src/Git/Revision.php
@@ -16,7 +16,7 @@ final class Revision
 
     public static function fromSha1(string $sha1) : self
     {
-        Assert::that($sha1)->alnum()->length(40);
+        Assert::that($sha1)->regex('/[a-zA-Z0-9]{40}/');
         $instance = new self();
         $instance->sha1 = $sha1;
         return $instance;

--- a/src/Git/Revision.php
+++ b/src/Git/Revision.php
@@ -16,7 +16,7 @@ final class Revision
 
     public static function fromSha1(string $sha1) : self
     {
-        Assert::that($sha1)->regex('/[a-zA-Z0-9]{40}/');
+        Assert::that($sha1)->regex('/^[a-zA-Z0-9]{40}$/');
         $instance = new self();
         $instance->sha1 = $sha1;
         return $instance;

--- a/src/Git/Revision.php
+++ b/src/Git/Revision.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Roave\ApiCompare\Git;
+
+use Assert\Assert;
+
+final class Revision
+{
+    /** @var string */
+    private $sha1;
+
+    private function __construct()
+    {
+    }
+
+    public static function fromSha1(string $sha1) : self
+    {
+        Assert::that($sha1)->alnum()->length(40);
+        $instance = new self();
+        $instance->sha1 = $sha1;
+        return $instance;
+    }
+
+    public function __toString() : string
+    {
+        return $this->sha1;
+    }
+}

--- a/test/unit/ChangeTest.php
+++ b/test/unit/ChangeTest.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace RoaveTest\ApiCompare;
+
+use Roave\ApiCompare\Change;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Roave\ApiCompare\Change
+ */
+final class ChangeTest extends TestCase
+{
+    public function testAdded() : void
+    {
+        $changeText = uniqid('changeText', true);
+        self::assertSame(
+            '     ADDED: ' . $changeText,
+            (string)Change::added($changeText, false)
+        );
+    }
+
+    public function testBcAdded() : void
+    {
+        $changeText = uniqid('changeText', true);
+        self::assertSame(
+            '[BC] ADDED: ' . $changeText,
+            (string)Change::added($changeText, true)
+        );
+    }
+
+    public function testChanged() : void
+    {
+        $changeText = uniqid('changeText', true);
+        self::assertSame(
+            '     CHANGED: ' . $changeText,
+            (string)Change::changed($changeText, false)
+        );
+    }
+
+    public function testBcChanged() : void
+    {
+        $changeText = uniqid('changeText', true);
+        self::assertSame(
+            '[BC] CHANGED: ' . $changeText,
+            (string)Change::changed($changeText, true)
+        );
+    }
+
+    public function testRemoved() : void
+    {
+        $changeText = uniqid('changeText', true);
+        self::assertSame(
+            '     REMOVED: ' . $changeText,
+            (string)Change::removed($changeText, false)
+        );
+    }
+
+    public function testBcRemoved() : void
+    {
+        $changeText = uniqid('changeText', true);
+        self::assertSame(
+            '[BC] REMOVED: ' . $changeText,
+            (string)Change::removed($changeText, true)
+        );
+    }
+}

--- a/test/unit/ChangesTest.php
+++ b/test/unit/ChangesTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace RoaveTest\ApiCompare;
+
+use InvalidArgumentException;
+use Roave\ApiCompare\Change;
+use Roave\ApiCompare\Changes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Roave\ApiCompare\Changes
+ */
+final class ChangesTest extends TestCase
+{
+    public function testFromArray() : void
+    {
+        $change = Change::added('added', true);
+
+        self::assertSame(
+            [$change],
+            iterator_to_array(Changes::fromArray([$change]))
+        );
+    }
+
+    /**
+     * @return mixed[]
+     * @throws \Exception
+     */
+    public function invalidChangeProvider() : array
+    {
+        return [
+            [random_int(1, 100)],
+            [random_int(1, 100) / 1000],
+            [uniqid('string', true)],
+            [random_bytes(24)],
+            [[]],
+            [null],
+            [true],
+            [false],
+            [new \stdClass()],
+        ];
+    }
+
+    /**
+     * @param mixed $invalidChange
+     * @dataProvider invalidChangeProvider
+     */
+    public function testFromArrayThowsExceptionWhenInvalidChangePassed($invalidChange) : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Changes::fromArray([$invalidChange]);
+    }
+
+    public function testWithAddedChange() : void
+    {
+        $change = Change::added('added', true);
+
+        self::assertSame(
+            [$change],
+            iterator_to_array(Changes::new()->withAddedChange($change))
+        );
+    }
+}

--- a/test/unit/Command/ApiCompareTest.php
+++ b/test/unit/Command/ApiCompareTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace RoaveTest\ApiCompare\Command;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Roave\ApiCompare\Command\ApiCompare;
+use PHPUnit\Framework\TestCase;
+use Roave\ApiCompare\Factory\DirectoryReflectorFactory;
+use Roave\ApiCompare\Git\CheckedOutRepository;
+use Roave\ApiCompare\Git\PerformCheckoutOfRevision;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @covers \Roave\ApiCompare\Command\ApiCompare
+ */
+final class ApiCompareTest extends TestCase
+{
+    public function testExecute() : void
+    {
+        $sourceRepository = CheckedOutRepository::fromPath(realpath(__DIR__ . '/../../../'));
+
+        $fromSha = sha1('fromRevision', false);
+        $toSha = sha1('toRevision', false);
+
+        /** @var InputInterface|MockObject $input */
+        $input = $this->createMock(InputInterface::class);
+        $input->expects(self::at(0))->method('getArgument')->with('from')->willReturn($fromSha);
+        $input->expects(self::at(1))->method('getArgument')->with('to')->willReturn($toSha);
+        /** @var OutputInterface|MockObject $output */
+        $output = $this->createMock(OutputInterface::class);
+        /** @var PerformCheckoutOfRevision|MockObject $git */
+        $git = $this->createMock(PerformCheckoutOfRevision::class);
+        $git->expects(self::at(0))
+            ->method('checkout')
+            ->with($sourceRepository, $fromSha)
+            ->willReturn($sourceRepository);
+        $git->expects(self::at(1))
+            ->method('checkout')
+            ->with($sourceRepository, $toSha)
+            ->willReturn($sourceRepository);
+        $git->expects(self::at(2))
+            ->method('remove')
+            ->with($sourceRepository);
+        $git->expects(self::at(3))
+            ->method('remove')
+            ->with($sourceRepository);
+
+        $command = new ApiCompare($git, new DirectoryReflectorFactory());
+
+        chdir((string)$sourceRepository);
+        $command->execute($input, $output);
+    }
+}

--- a/test/unit/Formatter/SymfonyConsoleTextFormatterTest.php
+++ b/test/unit/Formatter/SymfonyConsoleTextFormatterTest.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace RoaveTest\ApiCompare\Formatter;
+
+use Roave\ApiCompare\Change;
+use Roave\ApiCompare\Changes;
+use Roave\ApiCompare\Formatter\SymfonyConsoleTextFormatter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @covers \Roave\ApiCompare\Formatter\SymfonyConsoleTextFormatter
+ */
+final class SymfonyConsoleTextFormatterTest extends TestCase
+{
+    /**
+     * @throws \ReflectionException
+     */
+    public function testWrite() : void
+    {
+        $change1Text = uniqid('change1', true);
+        $change2Text = uniqid('change2', true);
+
+        $output = $this->createMock(OutputInterface::class);
+        $output->expects(self::at(0))
+            ->method('writeln')
+            ->with(sprintf('[BC] REMOVED: %s', $change1Text));
+        $output->expects(self::at(1))
+            ->method('writeln')
+            ->with(sprintf('     ADDED: %s', $change2Text));
+
+        (new SymfonyConsoleTextFormatter($output))->write(Changes::fromArray([
+            Change::removed($change1Text, true),
+            Change::added($change2Text, false),
+        ]));
+    }
+}

--- a/test/unit/Git/CheckedOutRepositoryTest.php
+++ b/test/unit/Git/CheckedOutRepositoryTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace RoaveTest\ApiCompare\Git;
+
+use Roave\ApiCompare\Git\CheckedOutRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Roave\ApiCompare\Git\CheckedOutRepository
+ */
+final class CheckedOutRepositoryTest extends TestCase
+{
+    public function testFromPath() : void
+    {
+        $path = sys_get_temp_dir() . '/' . uniqid('testPath', true);
+        mkdir($path, 0777, true);
+        mkdir($path . '/.git');
+
+        $checkedOutRepository = CheckedOutRepository::fromPath($path);
+        self::assertSame($path, (string)$checkedOutRepository);
+
+        rmdir($path . '/.git');
+        rmdir($path);
+    }
+}

--- a/test/unit/Git/GitCheckoutRevisionToTemporaryPathTest.php
+++ b/test/unit/Git/GitCheckoutRevisionToTemporaryPathTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace RoaveTest\ApiCompare\Git;
+
+use Roave\ApiCompare\Git\CheckedOutRepository;
+use Roave\ApiCompare\Git\GitCheckoutRevisionToTemporaryPath;
+use PHPUnit\Framework\TestCase;
+use Roave\ApiCompare\Git\Revision;
+
+/**
+ * @covers \Roave\ApiCompare\Git\GitCheckoutRevisionToTemporaryPath
+ */
+final class GitCheckoutRevisionToTemporaryPathTest extends TestCase
+{
+    public function testCheckoutAndRemove() : void
+    {
+        $sourceRepositoryPath = realpath(__DIR__ . '/../../../');
+
+        $git = new GitCheckoutRevisionToTemporaryPath();
+
+        $temporaryClone = $git->checkout(
+            CheckedOutRepository::fromPath($sourceRepositoryPath),
+            Revision::fromSha1('428327492a803b6e0c612b157a67a50a47275461')
+        );
+
+        self::assertInstanceOf(CheckedOutRepository::class, $temporaryClone);
+
+        $git->remove($temporaryClone);
+    }
+}

--- a/test/unit/Git/RevisionTest.php
+++ b/test/unit/Git/RevisionTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace RoaveTest\ApiCompare\Git;
+
+use InvalidArgumentException;
+use Roave\ApiCompare\Git\Revision;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Roave\ApiCompare\Git\Revision
+ */
+final class RevisionTest extends TestCase
+{
+    public function testFromSha1WithValidSha1() : void
+    {
+        $sha1 = sha1(uniqid('sha1', true));
+
+        self::assertSame($sha1, (string)Revision::fromSha1($sha1));
+    }
+
+    public function invalidRevisionProvider() : array
+    {
+        return [
+            [''],
+            ['a'],
+            [str_repeat('a', 39)],
+            [str_repeat('a', 41)],
+        ];
+    }
+
+    /**
+     * @param string $invalidRevision
+     * @dataProvider invalidRevisionProvider
+     */
+    public function testInvalidSha1Rejected(string $invalidRevision) : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Revision::fromSha1($invalidRevision);
+    }
+}


### PR DESCRIPTION
Prototype here for running via CLI.

Usage currently like:

```
$ bin/api-compare a:c <from-rev> <to-rev>
$ bin/api-compare a:c 41231369b30957bf89881f02163b51c512c63d6f a1dffda3b9a25d7be501a3d66e50e262c98b511f
```

Note: this is a VERY rough around the edges initial implementation, and doesn't satisfy all our requirements yet (from #13). For example it doesn't do revision parsing (so it has to be full revision at the moment).