### PR TITLE
Return 2 from CLI tool when changes are detected

### DIFF
--- a/bin/api-compare.php
+++ b/bin/api-compare.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Roave\ApiCompareCli;
 
 use Roave\ApiCompare\Command;
+use Roave\ApiCompare\Comparator;
 use Roave\ApiCompare\Factory\DirectoryReflectorFactory;
 use Roave\ApiCompare\Git\GetVersionCollectionFromGitRepository;
 use Roave\ApiCompare\Git\GitCheckoutRevisionToTemporaryPath;
@@ -28,7 +29,10 @@ use function file_exists;
             new DirectoryReflectorFactory(),
             new GitParseRevision(),
             new GetVersionCollectionFromGitRepository(),
-            new PickLastMinorVersionFromCollection()
+            new PickLastMinorVersionFromCollection(),
+            new Comparator(
+                new Comparator\BackwardsCompatibility\ClassBased\PropertyRemoved()
+            )
         );
 
         $application = new Application();

--- a/src/Changes.php
+++ b/src/Changes.php
@@ -5,9 +5,11 @@ namespace Roave\ApiCompare;
 
 use ArrayIterator;
 use Assert\Assert;
+use Countable;
 use IteratorAggregate;
+use function count;
 
-final class Changes implements IteratorAggregate
+final class Changes implements IteratorAggregate, Countable
 {
     /** @var Change[] */
     private $changes = [];
@@ -53,5 +55,13 @@ final class Changes implements IteratorAggregate
     public function getIterator() : ArrayIterator
     {
         return new ArrayIterator($this->changes);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function count() : int
+    {
+        return count($this->changes);
     }
 }

--- a/src/Comparator.php
+++ b/src/Comparator.php
@@ -10,7 +10,7 @@ use Roave\BetterReflection\Reflection\ReflectionParameter;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 
-final class Comparator
+class Comparator
 {
     /** @var ClassBased */
     private $classBasedComparisons;


### PR DESCRIPTION
Fixes #22 
Also makes `Comparator` non-final and injected into the command. Ideally we define an interface before we reach 1.0.0, see issue #28